### PR TITLE
Update Recovery Build.yml

### DIFF
--- a/.github/workflows/Recovery Build.yml
+++ b/.github/workflows/Recovery Build.yml
@@ -157,6 +157,7 @@ jobs:
         files: | 
           workspace/out/target/product/${{ github.event.inputs.DEVICE_NAME }}/${{ github.event.inputs.BUILD_TARGET }}.img
           workspace/out/target/product/${{ github.event.inputs.DEVICE_NAME }}/*.zip
+          workspace/out/target/product/${{ github.event.inputs.DEVICE_NAME }}/*vendor*.img
         name: ${{ github.event.inputs.DEVICE_NAME }}-${{ github.run_id }}
         tag_name: ${{ github.run_id }}
         body: |


### PR DESCRIPTION
*vendor*.img
Since [vendorboot]image need to compile with lunch so the img file compiled has vendor_boot file name. The actions cannot release & upload correct img file because has different names.