### PR TITLE
Remove OrangeFox manifest repo URL and fix SHRP manifest repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,5 +125,4 @@ Can be downloaded at [Release](../../releases)
 ## Remark
 
 #### TeamWin Recovery Project: https://github.com/minimal-manifest-twrp
-#### OrangeFox Recovery Project: https://gitlab.com/OrangeFox/Manifest
-#### SKYHAWK Recovery Project: https://github.com/SHRP/platform_manifest_twrp_omni
+#### SKYHAWK Recovery Project: https://github.com/SHRP/manifest


### PR DESCRIPTION
No need to keep OrangeFox manifest repo URL since there is already a [dedicated repo](https://github.com/azwhikaru/Action-OFRP-Builder) for building said recovery and current SHRP manifest repo URL leads to a 404 error (not found) which has been fixed as well